### PR TITLE
Allow user to specify which columns are searchable

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -711,7 +711,9 @@ class MUIDataTable extends React.Component {
       rowSelected: this.state.selectedRows.lookup[sIndex] ? true : false,
     }));
 
-    sortedData.sort(this.sortCompare(order));
+    if (!this.options.customSort) {
+      sortedData.sort(this.sortCompare(order));
+    }
 
     let tableData = [];
     let selectedRows = [];

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -703,7 +703,6 @@ class MUIDataTable extends React.Component {
   }
 
   sortTable(data, col, order) {
-
     let dataSrc = this.options.customSort ? this.options.customSort(data, col, order) : data;
 
     let sortedData = dataSrc.map((row, sIndex) => ({

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -85,8 +85,7 @@ class MUIDataTable extends React.Component {
       rowsPerPageOptions: PropTypes.array,
       filter: PropTypes.bool,
       sort: PropTypes.bool,
-      sortCompare: PropTypes.func,
-      sortedData: PropTypes.func,
+      customSort: PropTypes.func,
       search: PropTypes.bool,
       print: PropTypes.bool,
       viewColumns: PropTypes.bool,
@@ -167,8 +166,6 @@ class MUIDataTable extends React.Component {
       filter: true,
       sortFilterList: true,
       sort: true,
-      sortCompare: this.sortCompare,
-      sortedData: this.sortedData,
       search: true,
       print: true,
       viewColumns: true,
@@ -645,7 +642,7 @@ class MUIDataTable extends React.Component {
           }
 
           return {
-            curSelectedRows: selectedRows,
+            curSelectedRows: newRows,
             selectedRows: {
               data: newRows,
               lookup: selectedMap,
@@ -654,8 +651,7 @@ class MUIDataTable extends React.Component {
         },
         () => {
           if (this.options.onRowsSelect) {
-            console.log(this.state.curSelectedRows);
-            this.options.onRowsSelect(this.state.curSelectedRows.data[0], this.state.selectedRows.data);
+            this.options.onRowsSelect(this.state.curSelectedRows, this.state.selectedRows.data);
           }
         },
       );
@@ -695,7 +691,7 @@ class MUIDataTable extends React.Component {
     }
   };
 
-  sortCompare = (order) => {
+  sortCompare(order) {
     return (a, b) => {
       if (a.data === null) a.data = "";
       if (b.data === null) b.data = "";
@@ -706,18 +702,16 @@ class MUIDataTable extends React.Component {
     };
   }
 
-  sortedData = (data, col, order, props, state) => {
-    return data.map((row, sIndex) => ({
+  sortTable(data, col, order) {
+
+    let dataSrc = this.options.customSort ? this.options.customSort(data, col, order) : data;
+
+    let sortedData = dataSrc.map((row, sIndex) => ({
       data: row.data[col],
       position: sIndex,
       rowSelected: this.state.selectedRows.lookup[sIndex] ? true : false,
     }));
-  }
 
-  sortTable = (data, col, order) => {
-    let {props, state} = this,
-    sortedData = this.options.sortedData(data, col, order, props, state);
-    sortedData.sort(this.options.sortCompare(order));
     sortedData.sort(this.sortCompare(order));
 
     let tableData = [];
@@ -809,7 +803,6 @@ class MUIDataTable extends React.Component {
             />
             <MUIDataTableBody
               data={this.state.displayData}
-              onRowClick={this.options.onRowClick}
               count={rowCount}
               columns={columns}
               page={page}

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -711,7 +711,7 @@ class MUIDataTable extends React.Component {
       data: row.data[col],
       position: sIndex,
       rowSelected: this.state.selectedRows.lookup[sIndex] ? true : false,
-    }))
+    }));
   }
 
   sortTable = (data, col, order) => {

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -714,7 +714,7 @@ class MUIDataTable extends React.Component {
     }))
   }
 
-  sortTable = (data, col, order, props, state) => {
+  sortTable = (data, col, order) => {
     let {props, state} = this,
     sortedData = this.options.sortedData(data, col, order, props, state);
     sortedData.sort(this.options.sortCompare(order));

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -85,6 +85,8 @@ class MUIDataTable extends React.Component {
       rowsPerPageOptions: PropTypes.array,
       filter: PropTypes.bool,
       sort: PropTypes.bool,
+      sortCompare: PropTypes.func,
+      sortedData: PropTypes.func,
       search: PropTypes.bool,
       print: PropTypes.bool,
       viewColumns: PropTypes.bool,
@@ -165,6 +167,8 @@ class MUIDataTable extends React.Component {
       filter: true,
       sortFilterList: true,
       sort: true,
+      sortCompare: this.sortCompare,
+      sortedData: this.sortedData,
       search: true,
       print: true,
       viewColumns: true,
@@ -691,7 +695,7 @@ class MUIDataTable extends React.Component {
     }
   };
 
-  sortCompare(order) {
+  sortCompare = (order) => {
     return (a, b) => {
       if (a.data === null) a.data = "";
       if (b.data === null) b.data = "";
@@ -702,13 +706,18 @@ class MUIDataTable extends React.Component {
     };
   }
 
-  sortTable(data, col, order) {
-    let sortedData = data.map((row, sIndex) => ({
+  sortedData = (data, col, order, props, state) => {
+    return data.map((row, sIndex) => ({
       data: row.data[col],
       position: sIndex,
       rowSelected: this.state.selectedRows.lookup[sIndex] ? true : false,
-    }));
+    }))
+  }
 
+  sortTable = (data, col, order, props, state) => {
+    let {props, state} = this,
+    sortedData = this.options.sortedData(data, col, order, props, state);
+    sortedData.sort(this.options.sortCompare(order));
     sortedData.sort(this.sortCompare(order));
 
     let tableData = [];

--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -222,6 +222,7 @@ class MUIDataTable extends React.Component {
         filter: true,
         sort: true,
         sortDirection: null,
+        searchable: true
       };
 
       if (typeof column === "object") {
@@ -343,8 +344,9 @@ class MUIDataTable extends React.Component {
 
       const columnVal = columnValue === null ? "" : columnValue.toString();
       const searchCase = !this.options.caseSensitive ? columnVal.toLowerCase() : columnVal.toString();
+      const isSearchable = columns[index].searchable
 
-      if (searchText && searchCase.indexOf(searchText.toLowerCase()) >= 0) {
+      if (isSearchable && searchText && searchCase.indexOf(searchText.toLowerCase()) >= 0) {
         isSearchFound = true;
       }
     }


### PR DESCRIPTION
Adds a new column option `searchable` which defaults to `true`.
Setting it to false, will exclude that column from the search results.